### PR TITLE
fix: ignore incorrect files

### DIFF
--- a/src/main/java/io/codeclou/java/junit/xml/merger/JunitXmlParser.java
+++ b/src/main/java/io/codeclou/java/junit/xml/merger/JunitXmlParser.java
@@ -117,7 +117,12 @@ public class JunitXmlParser {
                 for (File f : filesList) {
                     if (f.getAbsoluteFile().toString().endsWith(".xml")) {
                         System.out.println("\033[32;1;2mInfo >> adding " + f.getName() +  " to TestSuites\033[0m");
-                        suites.getTestSuites().add(parseTestSuite(f));
+                        try {
+                            suites.getTestSuites().add(parseTestSuite(f));
+                        } catch (Exception e) {
+                            System.out.println("\033[31;1mError >> the file " + f.getName() + " cannot be read: ignored\033[0m");
+                            e.printStackTrace();
+                        }
                     }
                 }
                 Document xml = suites.toXml();


### PR DESCRIPTION
Sometimes, the input directory contains more XML files than just the xUnit files.

Ignoring erroneous files is the simplest approach. A more complex one is to provide a pattern for the files to read (`junit-*.xml`)